### PR TITLE
use Offsets class and update offset values for new Unity version

### DIFF
--- a/src/HackF5.UnitySpy/AssemblyImageFactory.cs
+++ b/src/HackF5.UnitySpy/AssemblyImageFactory.cs
@@ -58,7 +58,7 @@
             var domain = process.ReadPtr(domainAddress);
 
             //// pointer to array of structs of type _MonoAssembly
-            var assemblyArrayAddress = process.ReadPtr(domain + 0x70);
+            var assemblyArrayAddress = process.ReadPtr(domain + Offsets.MonoDomain_domain_assemblies);
             for (var assemblyAddress = assemblyArrayAddress;
                 assemblyAddress != Constants.NullPtr;
                 assemblyAddress = process.ReadPtr(assemblyAddress + 0x4))
@@ -68,7 +68,7 @@
                 var assemblyName = process.ReadAsciiString(assemblyNameAddress);
                 if (assemblyName == name)
                 {
-                    return new AssemblyImage(process, process.ReadPtr(assembly + 0x40));
+                    return new AssemblyImage(process, process.ReadPtr(assembly + Offsets.MonoAssembly_image ));
                 }
             }
 

--- a/src/HackF5.UnitySpy/Detail/Offsets.cs
+++ b/src/HackF5.UnitySpy/Detail/Offsets.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HackF5.UnitySpy.Detail
+{
+    class Offset
+    {
+    }
+}


### PR DESCRIPTION
I have updated the offsets as per https://github.com/HearthSim/HearthMirror/commit/e3d4d5c751817c5e0a3ebaaad81647c1d8cada8f#diff-35e9f643c0c09d42fae81c33b88ef2e8, and extracted them to an Offsets.cs class. 
I have kept the name of the offsets as they appear in HearthMirror, feel free to rename them :)

Also, I wasn't sure how to use these offsets when they were involved in ToInt32() method calls, so in these instances I left the original "magic number" untouched. Here as well, feel free to update them if needed :)