### PR TITLE
add Offsets class with updated values following Unity version update

### DIFF
--- a/src/HackF5.UnitySpy/AssemblyImageFactory.cs
+++ b/src/HackF5.UnitySpy/AssemblyImageFactory.cs
@@ -58,7 +58,7 @@
             var domain = process.ReadPtr(domainAddress);
 
             //// pointer to array of structs of type _MonoAssembly
-            var assemblyArrayAddress = process.ReadPtr(domain + 0x70);
+            var assemblyArrayAddress = process.ReadPtr(domain + Offsets.MonoDomain_domain_assemblies);
             for (var assemblyAddress = assemblyArrayAddress;
                 assemblyAddress != Constants.NullPtr;
                 assemblyAddress = process.ReadPtr(assemblyAddress + 0x4))
@@ -68,7 +68,7 @@
                 var assemblyName = process.ReadAsciiString(assemblyNameAddress);
                 if (assemblyName == name)
                 {
-                    return new AssemblyImage(process, process.ReadPtr(assembly + 0x40));
+                    return new AssemblyImage(process, process.ReadPtr(assembly + Offsets.MonoAssembly_image ));
                 }
             }
 

--- a/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
+++ b/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
@@ -87,7 +87,8 @@
             {
                 for (var definition = this.Process.ReadPtr(classCacheTableArray + tableItem);
                     definition != Constants.NullPtr;
-                    definition = this.Process.ReadPtr(definition + 0xa8))
+                    definition = this.Process.ReadPtr(definition + Offsets.MonoClass_next_class_cache))
+                //definition = this.Process.ReadPtr(definition + 0xa8))
                 {
                     definitions.GetOrAdd(definition, new TypeDefinition(this, definition));
                 }

--- a/src/HackF5.UnitySpy/Detail/Offsets.cs
+++ b/src/HackF5.UnitySpy/Detail/Offsets.cs
@@ -1,40 +1,78 @@
-﻿namespace HackF5.UnitySpy.Detail
-{    class Offsets
+﻿// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
+namespace HackF5.UnitySpy.Detail
+{
+    internal static class Offsets
     {
-        public static uint ImageDosHeader_e_lfanew = 0x3c;
-        public static uint ImageNTHeaders_Signature = 0x0;
-        public static uint ImageNTHeaders_Machine = 0x4;
-        public static uint ImageNTHeaders_ExportDirectoryAddress = 0x78;
-        public static uint ImageExportDirectory_NumberOfFunctions = 0x14;
-        public static uint ImageExportDirectory_AddressOfFunctions = 0x1c;
-        public static uint ImageExportDirectory_AddressOfNames = 0x20;
-        public static uint MonoDomain_sizeof = 0x144;
-        public static uint MonoDomain_domain_assemblies = 0x70;
-        public static uint MonoAssembly_sizeof = 0x54;
-        public static uint MonoAssembly_name = 0x8;
-        public static uint MonoAssembly_image = 0x40;
-        public static uint MonoImage_class_cache = 0x2a0;
-        public static uint MonoInternalHashTable_size = 0xc;
-        public static uint MonoInternalHashTable_table = 0x14;
-        public static uint MonoClass_parent = 0x24;
-        public static uint MonoClass_nested_in = 0x28;
-        public static uint MonoClass_runtime_info = 0xa8;
-        public static uint MonoClass_name = 0x34;
-        public static uint MonoClass_name_space = 0x38;
-        public static uint MonoClass_next_class_cache = 0xac;
-        public static uint MonoClass_fields = 0x78;
-        public static uint MonoClass_sizes = 0x5c;
-        public static uint MonoClass_byval_arg = 0x8c;
-        public static uint MonoClass_bitfields = 0x14;
-        public static uint MonoClass_field_count = 0x68;
-        public static uint MonoClassField_sizeof = 0x10;
-        public static uint MonoClassField_type = 0x0;
-        public static uint MonoClassField_name = 0x4;
-        public static uint MonoClassField_parent = 0x8;
-        public static uint MonoClassField_offset = 0xc;
-        public static uint MonoType_attrs = 0x4;
-        public static uint MonoType_sizeof = 0x8;
-        public static uint MonoClassRuntimeInfo_domain_vtables = 0x4;
-        public static uint MonoVTable_data = 0xc;
+        public const uint ImageDosHeader_e_lfanew = 0x3c;
+
+        public const uint ImageExportDirectory_AddressOfFunctions = 0x1c;
+
+        public const uint ImageExportDirectory_AddressOfNames = 0x20;
+
+        public const uint ImageExportDirectory_NumberOfFunctions = 0x14;
+
+        public const uint ImageNTHeaders_ExportDirectoryAddress = 0x78;
+
+        public const uint ImageNTHeaders_Machine = 0x4;
+
+        public const uint ImageNTHeaders_Signature = 0x0;
+
+        public const uint MonoAssembly_image = 0x40;
+
+        public const uint MonoAssembly_name = 0x8;
+
+        public const uint MonoAssembly_sizeof = 0x54;
+
+        public const uint MonoClass_bitfields = 0x14;
+
+        public const uint MonoClass_byval_arg = 0x8c;
+
+        public const uint MonoClass_field_count = 0x68;
+
+        public const uint MonoClass_fields = 0x78;
+
+        public const uint MonoClass_name = 0x34;
+
+        public const uint MonoClass_name_space = 0x38;
+
+        public const uint MonoClass_nested_in = 0x28;
+
+        public const uint MonoClass_next_class_cache = 0xac;
+
+        public const uint MonoClass_parent = 0x24;
+
+        public const uint MonoClass_runtime_info = 0xa8;
+
+        public const uint MonoClass_sizes = 0x5c;
+
+        public const uint MonoClassField_name = 0x4;
+
+        public const uint MonoClassField_offset = 0xc;
+
+        public const uint MonoClassField_parent = 0x8;
+
+        public const uint MonoClassField_sizeof = 0x10;
+
+        public const uint MonoClassField_type = 0x0;
+
+        public const uint MonoClassRuntimeInfo_domain_vtables = 0x4;
+
+        public const uint MonoDomain_domain_assemblies = 0x70;
+
+        public const uint MonoDomain_sizeof = 0x144;
+
+        public const uint MonoImage_class_cache = 0x2a0;
+
+        public const uint MonoInternalHashTable_size = 0xc;
+
+        public const uint MonoInternalHashTable_table = 0x14;
+
+        public const uint MonoType_attrs = 0x4;
+
+        public const uint MonoType_sizeof = 0x8;
+
+        public const uint MonoVTable_data = 0xc;
     }
 }

--- a/src/HackF5.UnitySpy/Detail/Offsets.cs
+++ b/src/HackF5.UnitySpy/Detail/Offsets.cs
@@ -1,0 +1,40 @@
+﻿namespace HackF5.UnitySpy.Detail
+{    class Offsets
+    {
+        public static uint ImageDosHeader_e_lfanew = 0x3c;
+        public static uint ImageNTHeaders_Signature = 0x0;
+        public static uint ImageNTHeaders_Machine = 0x4;
+        public static uint ImageNTHeaders_ExportDirectoryAddress = 0x78;
+        public static uint ImageExportDirectory_NumberOfFunctions = 0x14;
+        public static uint ImageExportDirectory_AddressOfFunctions = 0x1c;
+        public static uint ImageExportDirectory_AddressOfNames = 0x20;
+        public static uint MonoDomain_sizeof = 0x144;
+        public static uint MonoDomain_domain_assemblies = 0x70;
+        public static uint MonoAssembly_sizeof = 0x54;
+        public static uint MonoAssembly_name = 0x8;
+        public static uint MonoAssembly_image = 0x40;
+        public static uint MonoImage_class_cache = 0x2a0;
+        public static uint MonoInternalHashTable_size = 0xc;
+        public static uint MonoInternalHashTable_table = 0x14;
+        public static uint MonoClass_parent = 0x24;
+        public static uint MonoClass_nested_in = 0x28;
+        public static uint MonoClass_runtime_info = 0xa8;
+        public static uint MonoClass_name = 0x34;
+        public static uint MonoClass_name_space = 0x38;
+        public static uint MonoClass_next_class_cache = 0xac;
+        public static uint MonoClass_fields = 0x78;
+        public static uint MonoClass_sizes = 0x5c;
+        public static uint MonoClass_byval_arg = 0x8c;
+        public static uint MonoClass_bitfields = 0x14;
+        public static uint MonoClass_field_count = 0x68;
+        public static uint MonoClassField_sizeof = 0x10;
+        public static uint MonoClassField_type = 0x0;
+        public static uint MonoClassField_name = 0x4;
+        public static uint MonoClassField_parent = 0x8;
+        public static uint MonoClassField_offset = 0xc;
+        public static uint MonoType_attrs = 0x4;
+        public static uint MonoType_sizeof = 0x8;
+        public static uint MonoClassRuntimeInfo_domain_vtables = 0x4;
+        public static uint MonoVTable_data = 0xc;
+    }
+}

--- a/src/HackF5.UnitySpy/Detail/TypeDefinition.cs
+++ b/src/HackF5.UnitySpy/Detail/TypeDefinition.cs
@@ -42,19 +42,19 @@
                 throw new ArgumentNullException(nameof(image));
             }
 
-            this.bitFields = this.ReadUInt32(0x14);
-            this.fieldCount = this.ReadInt32(0x64);
-            this.lazyParent = new Lazy<TypeDefinition>(() => this.GetClassDefinition(0x24));
-            this.lazyNestedIn = new Lazy<TypeDefinition>(() => this.GetClassDefinition(0x28));
+            this.bitFields = this.ReadUInt32(Offsets.MonoClass_bitfields);
+            this.fieldCount = this.ReadInt32(Offsets.MonoClass_field_count);
+            this.lazyParent = new Lazy<TypeDefinition>(() => this.GetClassDefinition(Offsets.MonoClass_parent));
+            this.lazyNestedIn = new Lazy<TypeDefinition>(() => this.GetClassDefinition(Offsets.MonoClass_nested_in));
             this.lazyFullName = new Lazy<string>(this.GetFullName);
             this.lazyFields = new Lazy<IReadOnlyList<FieldDefinition>>(this.GetFields);
 
-            this.Name = this.ReadString(0x30);
-            this.NamespaceName = this.ReadString(0x34);
-            this.Size = this.ReadInt32(0x58);
-            var vtablePtr = this.ReadPtr(0xa4);
-            this.VTable = vtablePtr == Constants.NullPtr ? Constants.NullPtr : image.Process.ReadPtr(vtablePtr + 0x4);
-            this.TypeInfo = new TypeInfo(image, this.Address + 0x88);
+            this.Name = this.ReadString(Offsets.MonoClass_name);
+            this.NamespaceName = this.ReadString(Offsets.MonoClass_name_space);
+            this.Size = this.ReadInt32(Offsets.MonoClass_sizes);
+            var vtablePtr = this.ReadPtr(Offsets.MonoClass_runtime_info);
+            this.VTable = vtablePtr == Constants.NullPtr ? Constants.NullPtr : image.Process.ReadPtr(vtablePtr + Offsets.MonoClassRuntimeInfo_domain_vtables);
+            this.TypeInfo = new TypeInfo(image, this.Address + Offsets.MonoClass_byval_arg);
         }
 
         IReadOnlyList<IFieldDefinition> ITypeDefinition.Fields => this.Fields;
@@ -126,7 +126,7 @@
 
         private IReadOnlyList<FieldDefinition> GetFields()
         {
-            var firstField = this.ReadPtr(0x74);
+            var firstField = this.ReadPtr(Offsets.MonoClass_fields);
             if (firstField == Constants.NullPtr)
             {
                 return this.Parent?.Fields ?? Array.Empty<FieldDefinition>();


### PR DESCRIPTION
I have updated the offsets as per HearthSim/HearthMirror@e3d4d5c#diff-35e9f643c0c09d42fae81c33b88ef2e8, and extracted them to an Offsets.cs class.
I have kept the name of the offsets as they appear in HearthMirror, feel free to rename them :)

Also, I wasn't sure how to use these offsets when they were involved in ToInt32() method calls, so in these instances I left the original "magic number" untouched. Here as well, feel free to update them if needed :)

Would fix #1 