### PR TITLE
add support for running in an x64 environment

### DIFF
--- a/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
+++ b/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
@@ -88,7 +88,6 @@
                 for (var definition = this.Process.ReadPtr(classCacheTableArray + tableItem);
                     definition != Constants.NullPtr;
                     definition = this.Process.ReadPtr(definition + Offsets.MonoClass_next_class_cache))
-                //definition = this.Process.ReadPtr(definition + 0xa8))
                 {
                     definitions.GetOrAdd(definition, new TypeDefinition(this, definition));
                 }

--- a/src/HackF5.UnitySpy/Detail/Module.cs
+++ b/src/HackF5.UnitySpy/Detail/Module.cs
@@ -1,0 +1,20 @@
+﻿namespace HackF5.UnitySpy.Detail
+{
+    using System;
+
+    public class Module
+    {
+        public Module(string moduleName, IntPtr baseAddress, uint size)
+        {
+            this.ModuleName = moduleName;
+            this.BaseAddress = baseAddress;
+            this.Size = size;
+        }
+
+        public string ModuleName { get; set; }
+
+        public IntPtr BaseAddress { get; set; }
+
+        public uint Size { get; set; }
+    }
+}

--- a/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
+++ b/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
@@ -98,8 +98,8 @@
 
                 // may need supporting
                 case TypeCode.VAR:
-                    //// this is the type code for generic structs class-internals.h_MonoGenericParam. Good luck with
-                    //// that!
+                //// this is the type code for generic structs class-internals.h_MonoGenericParam. Good luck with
+                //// that!
                 case TypeCode.OBJECT:
                 case TypeCode.ARRAY:
                 case TypeCode.ENUM:
@@ -128,15 +128,10 @@
             }
         }
 
-        public byte[] ReadModule([NotNull] ProcessModule module)
+        public byte[] ReadModule(Module monoModule)
         {
-            if (module == null)
-            {
-                throw new ArgumentNullException(nameof(module));
-            }
-
-            var buffer = new byte[module.ModuleMemorySize];
-            this.ReadProcessMemory(buffer, module.BaseAddress);
+            var buffer = new byte[monoModule.Size];
+            this.ReadProcessMemory(buffer, monoModule.BaseAddress);
             return buffer;
         }
 

--- a/src/HackF5.UnitySpy/Native.cs
+++ b/src/HackF5.UnitySpy/Native.cs
@@ -1,0 +1,35 @@
+﻿namespace HackF5.UnitySpy
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Text;
+
+    internal class Native
+    {
+        // https://stackoverflow.com/questions/36431220/getting-a-list-of-dlls-currently-loaded-in-a-process-c-sharp
+        [DllImport("psapi.dll")]
+        public static extern bool EnumProcessModulesEx(IntPtr hProcess, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] [In][Out] IntPtr[] lphModule, int cb, [MarshalAs(UnmanagedType.U4)] out int lpcbNeeded, uint dwFilterFlag);
+
+        [DllImport("psapi.dll")]
+        public static extern uint GetModuleFileNameEx(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName, [In] [MarshalAs(UnmanagedType.U4)] uint nSize);
+
+        [DllImport("psapi.dll", SetLastError = true)]
+        public static extern bool GetModuleInformation(IntPtr hProcess, IntPtr hModule, out ModuleInformation lpmodinfo, uint cb);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ModuleInformation
+    {
+        public IntPtr lpBaseOfDll;
+        public uint SizeOfImage;
+        public IntPtr EntryPoint;
+    }
+
+    internal enum ModuleFilter
+    {
+        ListModulesDefault = 0x0,
+        ListModules32Bit = 0x01,
+        ListModules64Bit = 0x02,
+        ListModulesAll = 0x03,
+    }
+}


### PR DESCRIPTION
Needs to be merged after #4, as it reuses the new offsets done there

This PR updates the `GetMonoModule` method to be able to retrieve the 32-bit modules even when the current environment is 64-bit.

To be honest, parts of this code is above me - I tested it, it worked, and refactored some bits that I did understand, and left the rest as is.
So feel free to rewrite it however you see fit so that it matches the style you've been using until now :)

Cheers, and thanks again!