### PR TITLE
add HearthstoneLib project

### DIFF
--- a/src/HackF5.UnitySpy.Gui/HackF5.UnitySpy.Gui.csproj
+++ b/src/HackF5.UnitySpy.Gui/HackF5.UnitySpy.Gui.csproj
@@ -40,6 +40,54 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>1701;1702;CA1724;CA1031</NoWarn>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoWarn>1701;1702;CA1724;CA1031</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>..\rules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>1701;1702;CA1724;CA1031</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>..\rules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoWarn>1701;1702;CA1724;CA1031</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>..\rules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>1701;1702;CA1724;CA1031</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>..\rules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=4.9.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.9.2\lib\net45\Autofac.dll</HintPath>

--- a/src/HackF5.UnitySpy.HearthstoneLib/CollectionCard.cs
+++ b/src/HackF5.UnitySpy.HearthstoneLib/CollectionCard.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HackF5.UnitySpy.HearthstoneLib
+{
+    public class CollectionCard
+    {
+        public string CardId { get; set; }
+
+        public int Count { get; set; }
+
+        public int PremiumCount { get; set; }
+    }
+}

--- a/src/HackF5.UnitySpy.HearthstoneLib/HackF5.UnitySpy.HearthstoneLib.csproj
+++ b/src/HackF5.UnitySpy.HearthstoneLib/HackF5.UnitySpy.HearthstoneLib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HackF5.UnitySpy\HackF5.UnitySpy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/HackF5.UnitySpy.HearthstoneLib/MindVision.cs
+++ b/src/HackF5.UnitySpy.HearthstoneLib/MindVision.cs
@@ -1,0 +1,59 @@
+﻿
+
+namespace HackF5.UnitySpy.HearthstoneLib
+{
+    using System;
+    using System.Diagnostics;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class MindVision
+    {
+        private IAssemblyImage image;
+
+        public MindVision()
+        {
+            var process = Process.GetProcessesByName("Hearthstone").FirstOrDefault();
+            this.image = AssemblyImageFactory.Create(process.Id);
+        }
+
+        public List<CollectionCard> GetCollection()
+        {
+            List<CollectionCard> collectionCards = new List<CollectionCard>();
+            var collectibleCards = image["CollectionManager"]["s_instance"]?["m_collectibleCards"];
+            if (collectibleCards != null)
+            {
+                var items = collectibleCards["_items"];
+                int size = collectibleCards["_size"];
+                for (var i = 0; i < size; i++)
+                {
+                    string cardId = items[i]["m_EntityDef"]["m_cardIdInternal"];
+                    if (string.IsNullOrEmpty(cardId))
+                    {
+                        continue;
+                    }
+                    int count = items[i]["<OwnedCount>k__BackingField"];
+                    int premium = items[i]["m_PremiumType"];
+                    var card = collectionCards.Where(existingCard => existingCard.CardId == cardId).FirstOrDefault();
+                    if (card == null)
+                    {
+                        card = new CollectionCard
+                        {
+                            CardId = cardId
+                        };
+                        collectionCards.Add(card);
+                    }
+                    if (premium == 1)
+                    {
+                        card.PremiumCount = count;
+                    } 
+                    else
+                    {
+                        card.Count = count;
+                    }
+                }
+            }
+            return collectionCards;
+        }
+    }
+}

--- a/src/HackF5.UnitySpy.Tests/HackF5.UnitySpy.HearthstoneLib.Tests.csproj
+++ b/src/HackF5.UnitySpy.Tests/HackF5.UnitySpy.HearthstoneLib.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <Platforms>AnyCPU;x86</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HackF5.UnitySpy.HearthstoneLib\HackF5.UnitySpy.HearthstoneLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/HackF5.UnitySpy.Tests/TestHearthstoneLibApi.cs
+++ b/src/HackF5.UnitySpy.Tests/TestHearthstoneLibApi.cs
@@ -1,0 +1,21 @@
+
+
+namespace HackF5.UnitySpy.HearthstoneLib.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+
+    // This needs to be run while Hearthstone is running
+    [TestClass]
+    public class TestHearthstoneLibApi
+    {
+        [TestMethod]
+        public void TestRetrieveCollection()
+        {
+            var collection = new MindVision().GetCollection();
+            Assert.IsNotNull(collection);
+            Assert.IsTrue(collection.Count > 0, "collection should not be empty");
+            Console.WriteLine("Collection had " + collection.Count + " cards");
+        }
+    }
+}

--- a/src/HackF5.UnitySpy.sln
+++ b/src/HackF5.UnitySpy.sln
@@ -16,20 +16,68 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".shared", ".shared", "{DD35
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HackF5.UnitySpy.Gui", "HackF5.UnitySpy.Gui\HackF5.UnitySpy.Gui.csproj", "{53214F8D-8702-490D-930D-6DA45DBEBD85}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HackF5.UnitySpy.HearthstoneLib.Tests", "HackF5.UnitySpy.Tests\HackF5.UnitySpy.HearthstoneLib.Tests.csproj", "{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HackF5.UnitySpy.HearthstoneLib", "HackF5.UnitySpy.HearthstoneLib\HackF5.UnitySpy.HearthstoneLib.csproj", "{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7207C1B6-4688-418E-A590-380C9488260F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7207C1B6-4688-418E-A590-380C9488260F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7207C1B6-4688-418E-A590-380C9488260F}.Debug|x64.ActiveCfg = Debug|x64
+		{7207C1B6-4688-418E-A590-380C9488260F}.Debug|x64.Build.0 = Debug|x64
+		{7207C1B6-4688-418E-A590-380C9488260F}.Debug|x86.ActiveCfg = Debug|x86
+		{7207C1B6-4688-418E-A590-380C9488260F}.Debug|x86.Build.0 = Debug|x86
 		{7207C1B6-4688-418E-A590-380C9488260F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7207C1B6-4688-418E-A590-380C9488260F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7207C1B6-4688-418E-A590-380C9488260F}.Release|x64.ActiveCfg = Release|x64
+		{7207C1B6-4688-418E-A590-380C9488260F}.Release|x64.Build.0 = Release|x64
+		{7207C1B6-4688-418E-A590-380C9488260F}.Release|x86.ActiveCfg = Release|x86
+		{7207C1B6-4688-418E-A590-380C9488260F}.Release|x86.Build.0 = Release|x86
 		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Debug|x64.ActiveCfg = Debug|x64
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Debug|x64.Build.0 = Debug|x64
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Debug|x86.ActiveCfg = Debug|x86
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Debug|x86.Build.0 = Debug|x86
 		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Release|x64.ActiveCfg = Release|x64
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Release|x64.Build.0 = Release|x64
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Release|x86.ActiveCfg = Release|x86
+		{53214F8D-8702-490D-930D-6DA45DBEBD85}.Release|x86.Build.0 = Release|x86
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Debug|x64.Build.0 = Debug|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Debug|x86.ActiveCfg = Debug|x86
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Debug|x86.Build.0 = Debug|x86
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Release|x64.ActiveCfg = Release|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Release|x64.Build.0 = Release|Any CPU
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Release|x86.ActiveCfg = Release|x86
+		{1D5B71A2-9B4B-4772-A53B-B3BCB3242547}.Release|x86.Build.0 = Release|x86
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Debug|x64.Build.0 = Debug|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Debug|x86.Build.0 = Debug|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Release|x64.ActiveCfg = Release|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Release|x64.Build.0 = Release|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Release|x86.ActiveCfg = Release|Any CPU
+		{2AB0622D-919B-4CD1-85E1-7E02B6EB16D3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/HackF5.UnitySpy/HackF5.UnitySpy.csproj
+++ b/src/HackF5.UnitySpy/HackF5.UnitySpy.csproj
@@ -7,9 +7,20 @@
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\HackF5.UnitySpy.snk</AssemblyOriginatorKeyFile>
+    <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>


### PR DESCRIPTION
Needs to be merged after #5 as it reuses the code done there

This adds a new project, HearthstoneLib, that exposes a user-friendly API that hides the internal complexity of navigating Hearthstone's memory.

I'm mostly a beginning both at Visual Studio and C#, so as usual, please don't hesitate to comment / rewrite whatever you feel necessary, that will help me learn :)