### PR TITLE
Mono bleeding edge

### DIFF
--- a/src/HackF5.UnitySpy.Tests/TestHearthstoneLibApi.cs
+++ b/src/HackF5.UnitySpy.Tests/TestHearthstoneLibApi.cs
@@ -2,6 +2,9 @@ namespace HackF5.UnitySpy.HearthstoneLib.Tests
 {
     using JetBrains.Annotations;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
 
     // This needs to be run while Hearthstone is running
     [TestClass]
@@ -34,6 +37,22 @@ namespace HackF5.UnitySpy.HearthstoneLib.Tests
         {
             var dungeonInfo = new MindVision().GetDungeonInfoCollection();
             Assert.IsNotNull(dungeonInfo);
+        }
+
+        [TestMethod]
+        public void MyTestMethod()
+        {
+            var process = Process.GetProcessesByName("Hearthstone").FirstOrDefault();
+            if (process == null)
+            {
+                throw new InvalidOperationException(
+                    "Failed to find Hearthstone executable. Please check that Hearthstone is running.");
+            }
+
+            var image = AssemblyImageFactory.Create(process.Id);
+            var type = image.GetTypeDefinition("CollectionManager");
+            var instance = type.GetStaticValue<IManagedObjectInstance>("s_instance");
+            var cards = instance.GetValue<IManagedObjectInstance>("m_collectibleCards");
         }
     }
 }

--- a/src/HackF5.UnitySpy.Tests/TestHearthstoneLibApi.cs
+++ b/src/HackF5.UnitySpy.Tests/TestHearthstoneLibApi.cs
@@ -53,6 +53,7 @@ namespace HackF5.UnitySpy.HearthstoneLib.Tests
             var type = image.GetTypeDefinition("CollectionManager");
             var instance = type.GetStaticValue<IManagedObjectInstance>("s_instance");
             var cards = instance.GetValue<IManagedObjectInstance>("m_collectibleCards");
+            var other = cards;
         }
     }
 }

--- a/src/HackF5.UnitySpy/AssemblyImageFactory.cs
+++ b/src/HackF5.UnitySpy/AssemblyImageFactory.cs
@@ -104,7 +104,7 @@
                 modules.Add(module);
             }
 
-            return modules.FirstOrDefault(module => module.ModuleName == "mono.dll");
+            return modules.FirstOrDefault(module => module.ModuleName == "mono-2.0-bdwgc.dll");
         }
 
         private static int GetRootDomainFunctionAddress(byte[] moduleDump, ModuleInfo monoModuleInfo)

--- a/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
+++ b/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
@@ -77,9 +77,9 @@
         {
             var definitions = new ConcurrentDictionary<uint, TypeDefinition>();
 
-            const uint classCache = 0x2a0u;
-            var classCacheSize = this.ReadUInt32(classCache + 0xc);
-            var classCacheTableArray = this.ReadPtr(classCache + 0x14);
+            const uint classCache = MonoLibraryOffsets.ImageClassCache;
+            var classCacheSize = this.ReadUInt32(classCache + MonoLibraryOffsets.HashTableSize);
+            var classCacheTableArray = this.ReadPtr(classCache + MonoLibraryOffsets.HashTableTable);
 
             for (var tableItem = 0u;
                 tableItem < (classCacheSize * Constants.SizeOfPtr);

--- a/src/HackF5.UnitySpy/Detail/MemoryObject.cs
+++ b/src/HackF5.UnitySpy/Detail/MemoryObject.cs
@@ -27,5 +27,7 @@
         protected string ReadString(uint offset) => this.Process.ReadAsciiStringPtr(this.Address + offset);
 
         protected uint ReadUInt32(uint offset) => this.Process.ReadUInt32(this.Address + offset);
+
+        protected byte ReadByte(uint offset) => this.Process.ReadByte(this.Address + offset);
     }
 }

--- a/src/HackF5.UnitySpy/Detail/MonoClassKind.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoClassKind.cs
@@ -1,0 +1,12 @@
+﻿namespace HackF5.UnitySpy.Detail
+{
+    public enum MonoClassKind
+    {
+        Def = 1,
+        GTg = 2,
+        GInst = 3,
+        GParam = 4,
+        Array = 5,
+        Pointer = 6,
+    }
+}

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -20,6 +20,8 @@ namespace HackF5.UnitySpy.Detail
 
         public const uint TypeDefinitionFields = 0x60;
 
+        public const uint TypeDefinitionFieldSize = 0x10;
+
         public const uint TypeDefinitionName = 0x2c;
 
         public const uint TypeDefinitionNamespace = 0x30;

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -37,5 +37,13 @@ namespace HackF5.UnitySpy.Detail
         public const uint TypeDefinitionRuntimeInfoDomainVtables = 0x4;
 
         public const uint ReferencedAssemblies = 0x6c;
+
+        public const uint TypeDefinitionVTableSize = 0x38;
+
+        public const uint TypeDefinitionClassKind = 0x1e;
+
+        public const uint TypeDefinitionSizeOf = 0x94;
+
+        public const uint VTable = 0x28;
     }
 }

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -1,34 +1,41 @@
 ﻿// ReSharper disable IdentifierTypo
 namespace HackF5.UnitySpy.Detail
 {
+    // Remember that here pointers are 4 bytes
     internal static class MonoLibraryOffsets
     {
-        public const uint AssemblyImage = 0x40;
+        public const uint AssemblyImage = 0x44;
+
+        public const uint ImageClassCache = 0x354;
+
+        public const uint HashTableSize = 0xc;
+
+        public const uint HashTableTable = 0x14;
 
         public const uint TypeDefinitionBitFields = 0x14;
 
-        public const uint TypeDefinitionByValArg = 0x8c;
+        public const uint TypeDefinitionByValArg = 0x74;
 
-        public const uint TypeDefinitionFieldCount = 0x68;
+        public const uint TypeDefinitionFieldCount = 0xa4;
 
-        public const uint TypeDefinitionFields = 0x78;
+        public const uint TypeDefinitionFields = 0x60;
 
-        public const uint TypeDefinitionName = 0x34;
+        public const uint TypeDefinitionName = 0x2c;
 
-        public const uint TypeDefinitionNamespace = 0x38;
+        public const uint TypeDefinitionNamespace = 0x30;
 
-        public const uint TypeDefinitionNestedIn = 0x28;
+        public const uint TypeDefinitionNestedIn = 0x24;
 
-        public const uint TypeDefinitionNextClassCache = 0xac;
+        public const uint TypeDefinitionNextClassCache = 0xa8;
 
-        public const uint TypeDefinitionParent = 0x24;
+        public const uint TypeDefinitionParent = 0x20;
 
-        public const uint TypeDefinitionRuntimeInfo = 0xa8;
+        public const uint TypeDefinitionRuntimeInfo = 0x84;
 
         public const uint TypeDefinitionSize = 0x5c;
 
         public const uint TypeDefinitionRuntimeInfoDomainVtables = 0x4;
 
-        public const uint ReferencedAssemblies = 0x70;
-   }
+        public const uint ReferencedAssemblies = 0x6c;
+    }
 }

--- a/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
+++ b/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
@@ -153,6 +153,11 @@
             return this.ReadBufferValue(address, sizeof(uint), b => b.ToUInt32());
         }
 
+        public byte ReadByte(uint address)
+        {
+            return this.ReadBufferValue(address, sizeof(byte), b => b.ToByte());
+        }
+
         [DllImport("kernel32", SetLastError = true)]
         private static extern bool ReadProcessMemory(
             IntPtr hProcess,

--- a/src/HackF5.UnitySpy/Util/ConversionUtils.cs
+++ b/src/HackF5.UnitySpy/Util/ConversionUtils.cs
@@ -29,5 +29,7 @@
         public static float ToSingle(this byte[] buffer) => BitConverter.ToSingle(buffer, 0);
 
         public static double ToDouble(this byte[] buffer) => BitConverter.ToDouble(buffer, 0);
+
+        public static byte ToByte(this byte[] buffer) => buffer[0];
     }
 }


### PR DESCRIPTION
Updates to the memory reading to be compatible with the 2018.4_mono_bleeding_edge version of mono used by Unity 2018.4