### PR TITLE
Added 64 bits support and Offsets based on unity version

### DIFF
--- a/src/HackF5.UnitySpy/AssemblyImageFactory.cs
+++ b/src/HackF5.UnitySpy/AssemblyImageFactory.cs
@@ -65,6 +65,11 @@
                 if (assemblyName == name)
                 {
                     return new AssemblyImage(process, process.ReadPtr(assembly + MonoLibraryOffsets.AssemblyImage));
+                    //return new AssemblyImage(process, process.ReadPtr(assembly + 0x44)); -> CollectionManager is null if we have this
+                    //return new AssemblyImage(process, process.ReadPtr(assembly + 0x54)); -> CollectionManager is null if we have this
+                    //return new AssemblyImage(process, process.ReadPtr(assembly + 0x6c)); -> CollectionManager is null if we have this
+                    //return new AssemblyImage(process, process.ReadPtr(assembly + 0xac)); -> CollectionManager is null if we have this
+                    //return new AssemblyImage(process, process.ReadPtr(assembly + 0xac));
                 }
             }
 
@@ -104,7 +109,7 @@
                 modules.Add(module);
             }
 
-            return modules.FirstOrDefault(module => module.ModuleName == "mono.dll");
+            return modules.FirstOrDefault(module => module.ModuleName == "mono-2.0-bdwgc.dll");
         }
 
         private static int GetRootDomainFunctionAddress(byte[] moduleDump, ModuleInfo monoModuleInfo)

--- a/src/HackF5.UnitySpy/AssemblyImageFactory.cs
+++ b/src/HackF5.UnitySpy/AssemblyImageFactory.cs
@@ -42,25 +42,39 @@
             var process = new ProcessFacade(processId);
             var monoModule = AssemblyImageFactory.GetMonoModule(process);
             var moduleDump = process.ReadModule(monoModule);
-            var rootDomainFunctionAddress = AssemblyImageFactory.GetRootDomainFunctionAddress(moduleDump, monoModule);
+            var rootDomainFunctionAddress = AssemblyImageFactory.GetRootDomainFunctionAddress(moduleDump, monoModule, process.Is64Bits);
 
             return AssemblyImageFactory.GetAssemblyImage(process, assemblyName, rootDomainFunctionAddress);
         }
 
         private static AssemblyImage GetAssemblyImage(ProcessFacade process, string name, IntPtr rootDomainFunctionAddress)
         {
-            var domainAddress = process.ReadPtr(rootDomainFunctionAddress + 1);
-            //// pointer to struct of type _MonoDomain
-            var domain = process.ReadPtr(domainAddress);
+
+            IntPtr domain;
+            if (process.Is64Bits)
+            {
+                // Offsets taken by decompiling the 64 bits version of mono-2.0-bdwgc.dll
+                // mov rax, [rip + 0x46ad39]
+                // ret
+                var offset = process.ReadInt32(rootDomainFunctionAddress + 3) + 7;
+                //// pointer to struct of type _MonoDomain
+                domain = process.ReadPtr(rootDomainFunctionAddress + offset);
+            } 
+            else
+            {
+                var domainAddress = process.ReadPtr(rootDomainFunctionAddress + 1);
+                //// pointer to struct of type _MonoDomain
+                domain = process.ReadPtr(domainAddress);
+            }
 
             //// pointer to array of structs of type _MonoAssembly
             var assemblyArrayAddress = process.ReadPtr(domain + process.MonoLibraryOffsets.ReferencedAssemblies);
             for (var assemblyAddress = assemblyArrayAddress;
                 assemblyAddress != Constants.NullPtr;
-                assemblyAddress = process.ReadPtr(assemblyAddress + 0x4))
+                assemblyAddress = process.ReadPtr(assemblyAddress + process.SizeOfPtr))
             {
                 var assembly = process.ReadPtr(assemblyAddress);
-                var assemblyNameAddress = process.ReadPtr(assembly + 0x8);
+                var assemblyNameAddress = process.ReadPtr(assembly + (process.SizeOfPtr * 2));
                 var assemblyName = process.ReadAsciiString(assemblyNameAddress);
                 if (assemblyName == name)
                 {
@@ -112,25 +126,23 @@
             return modules.FirstOrDefault(module => module.ModuleName == "mono-2.0-bdwgc.dll");
         }
 
-        private static IntPtr GetRootDomainFunctionAddress(byte[] moduleDump, ModuleInfo monoModuleInfo)
+        private static IntPtr GetRootDomainFunctionAddress(byte[] moduleDump, ModuleInfo monoModuleInfo, bool is64Bits)
         {
             // offsets taken from https://docs.microsoft.com/en-us/windows/desktop/Debug/pe-format
             // ReSharper disable once CommentTypo
-            var startIndex = moduleDump.ToInt32(0x3c); // lfanew
+            var startIndex = moduleDump.ToInt32(PEFormatOffsets.Signature); // lfanew
 
-            var exportDirectoryIndex = startIndex + 0x78;
+            var exportDirectoryIndex = startIndex + PEFormatOffsets.GetExportDirectoryIndex(is64Bits);
             var exportDirectory = moduleDump.ToInt32(exportDirectoryIndex);
 
-            var numberOfFunctions = moduleDump.ToInt32(exportDirectory + 0x14);
-            var functionAddressArrayIndex = moduleDump.ToInt32(exportDirectory + 0x1c);
-            var functionNameArrayIndex = moduleDump.ToInt32(exportDirectory + 0x20);
-
-            var sizeOfFuntionEntry = 4;
+            var numberOfFunctions = moduleDump.ToInt32(exportDirectory + PEFormatOffsets.NumberOfFunctions);
+            var functionAddressArrayIndex = moduleDump.ToInt32(exportDirectory + PEFormatOffsets.FunctionAddressArrayIndex);
+            var functionNameArrayIndex = moduleDump.ToInt32(exportDirectory + PEFormatOffsets.FunctionNameArrayIndex);
 
             var rootDomainFunctionAddress = Constants.NullPtr;
             for (var functionIndex = 0;
-                functionIndex < (numberOfFunctions * sizeOfFuntionEntry);
-                functionIndex += sizeOfFuntionEntry)
+                functionIndex < (numberOfFunctions * PEFormatOffsets.FunctionEntrySize);
+                functionIndex += PEFormatOffsets.FunctionEntrySize)
             {
                 var functionNameIndex = moduleDump.ToInt32(functionNameArrayIndex + functionIndex);
                 var functionName = moduleDump.ToAsciiString(functionNameIndex);

--- a/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
+++ b/src/HackF5.UnitySpy/Detail/AssemblyImage.cs
@@ -1,5 +1,6 @@
 ﻿namespace HackF5.UnitySpy.Detail
 {
+    using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
@@ -41,7 +42,10 @@
                     continue;
                 }
 
-                this.typeDefinitionsByFullName.Add(definition.FullName, definition);
+                if (!this.typeDefinitionsByFullName.ContainsKey(definition.FullName))
+                {
+                    this.typeDefinitionsByFullName.Add(definition.FullName, definition);
+                }
             }
         }
 
@@ -77,9 +81,9 @@
         {
             var definitions = new ConcurrentDictionary<uint, TypeDefinition>();
 
-            const uint classCache = 0x2a0u;
-            var classCacheSize = this.ReadUInt32(classCache + 0xc);
-            var classCacheTableArray = this.ReadPtr(classCache + 0x14);
+            const uint classCache = MonoLibraryOffsets.ImageClassCache;
+            var classCacheSize = this.ReadUInt32(classCache + MonoLibraryOffsets.HashTableSize);
+            var classCacheTableArray = this.ReadPtr(classCache + MonoLibraryOffsets.HashTableTable);
 
             for (var tableItem = 0u;
                 tableItem < (classCacheSize * Constants.SizeOfPtr);

--- a/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
+++ b/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
@@ -37,8 +37,7 @@
 
         public TValue GetValue<TValue>(IntPtr address)
         {
-            // TODO check this 8 value for 64 bits might be 16
-            var offset = this.Offset - (this.DeclaringType.IsValueType ? 8 : 0);
+            var offset = this.Offset - (this.DeclaringType.IsValueType ? this.Process.SizeOfPtr * 2 : 0);
             return (TValue)this.TypeInfo.GetValue(address + offset);
         }
     }

--- a/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
+++ b/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
@@ -19,8 +19,8 @@
         {
             this.DeclaringType = declaringType;
             this.TypeInfo = new TypeInfo(declaringType.Image, this.ReadPtr(0x0));
-            this.Name = this.ReadString(0x4);
-            this.Offset = this.ReadInt32(0xc);
+            this.Name = this.ReadString(this.Process.SizeOfPtr);
+            this.Offset = this.ReadInt32(this.Process.SizeOfPtr * 3);
         }
 
         ITypeDefinition IFieldDefinition.DeclaringType => this.DeclaringType;
@@ -37,6 +37,7 @@
 
         public TValue GetValue<TValue>(IntPtr address)
         {
+            // TODO check this 8 value for 64 bits might be 16
             var offset = this.Offset - (this.DeclaringType.IsValueType ? 8 : 0);
             return (TValue)this.TypeInfo.GetValue(address + offset);
         }

--- a/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
+++ b/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
@@ -18,8 +18,15 @@
             : base((declaringType ?? throw new ArgumentNullException(nameof(declaringType))).Image, address)
         {
             this.DeclaringType = declaringType;
+
+            // MonoType        *type;
             this.TypeInfo = new TypeInfo(declaringType.Image, this.ReadPtr(0x0));
+
+            // MonoType        *name;
             this.Name = this.ReadString(this.Process.SizeOfPtr);
+
+            // wee need to skip MonoClass *parent field so we add
+            // 3 pointer sizes (*type, *name, *parent) to the base address
             this.Offset = this.ReadInt32(this.Process.SizeOfPtr * 3);
         }
 

--- a/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
+++ b/src/HackF5.UnitySpy/Detail/FieldDefinition.cs
@@ -14,7 +14,7 @@
         "Field: {" + nameof(FieldDefinition.Offset) + "} - {" + nameof(FieldDefinition.Name) + "}")]
     public class FieldDefinition : MemoryObject, IFieldDefinition
     {
-        public FieldDefinition([NotNull] TypeDefinition declaringType, uint address)
+        public FieldDefinition([NotNull] TypeDefinition declaringType, IntPtr address)
             : base((declaringType ?? throw new ArgumentNullException(nameof(declaringType))).Image, address)
         {
             this.DeclaringType = declaringType;
@@ -35,10 +35,10 @@
 
         public TypeInfo TypeInfo { get; }
 
-        public TValue GetValue<TValue>(uint address)
+        public TValue GetValue<TValue>(IntPtr address)
         {
             var offset = this.Offset - (this.DeclaringType.IsValueType ? 8 : 0);
-            return (TValue)this.TypeInfo.GetValue((uint)(address + offset));
+            return (TValue)this.TypeInfo.GetValue(address + offset);
         }
     }
 }

--- a/src/HackF5.UnitySpy/Detail/ManagedClassInstance.cs
+++ b/src/HackF5.UnitySpy/Detail/ManagedClassInstance.cs
@@ -12,11 +12,11 @@
     [PublicAPI]
     public class ManagedClassInstance : ManagedObjectInstance
     {
-        private readonly uint definitionAddress;
+        private readonly IntPtr definitionAddress;
 
-        private readonly uint vtable;
+        private readonly IntPtr vtable;
 
-        public ManagedClassInstance([NotNull] AssemblyImage image, uint address)
+        public ManagedClassInstance([NotNull] AssemblyImage image, IntPtr address)
             : base(image, address)
         {
             if (image == null)

--- a/src/HackF5.UnitySpy/Detail/ManagedObjectInstance.cs
+++ b/src/HackF5.UnitySpy/Detail/ManagedObjectInstance.cs
@@ -4,7 +4,7 @@
 
     public abstract class ManagedObjectInstance : MemoryObject, IManagedObjectInstance
     {
-        protected ManagedObjectInstance(AssemblyImage image, uint address)
+        protected ManagedObjectInstance(AssemblyImage image, IntPtr address)
             : base(image, address)
         {
         }

--- a/src/HackF5.UnitySpy/Detail/ManagedStructInstance.cs
+++ b/src/HackF5.UnitySpy/Detail/ManagedStructInstance.cs
@@ -12,7 +12,7 @@
     [PublicAPI]
     public class ManagedStructInstance : ManagedObjectInstance
     {
-        public ManagedStructInstance([NotNull] TypeDefinition typeDefinition, uint address)
+        public ManagedStructInstance([NotNull] TypeDefinition typeDefinition, IntPtr address)
             : base((typeDefinition ?? throw new ArgumentNullException(nameof(typeDefinition))).Image, address)
         {
             // value type pointers contain no type information as a significant performance optimization. in memory

--- a/src/HackF5.UnitySpy/Detail/MemoryObject.cs
+++ b/src/HackF5.UnitySpy/Detail/MemoryObject.cs
@@ -1,4 +1,6 @@
-﻿namespace HackF5.UnitySpy.Detail
+﻿using System;
+
+namespace HackF5.UnitySpy.Detail
 {
     /// <summary>
     /// The base type for all objects accessed in a process' memory. Every object has an address in memory
@@ -6,13 +8,13 @@
     /// </summary>
     public abstract class MemoryObject : IMemoryObject
     {
-        protected MemoryObject(AssemblyImage image, uint address)
+        protected MemoryObject(AssemblyImage image, IntPtr address)
         {
             this.Image = image;
             this.Address = address;
         }
 
-        public uint GetAddress()
+        public IntPtr GetAddress()
         {
             return this.Address;
         }
@@ -23,16 +25,16 @@
 
         public virtual ProcessFacade Process => this.Image.Process;
 
-        protected uint Address { get; }
+        protected IntPtr Address { get; }
 
-        protected int ReadInt32(uint offset) => this.Process.ReadInt32(this.Address + offset);
+        protected int ReadInt32(int offset) => this.Process.ReadInt32(this.Address + offset);
 
-        protected uint ReadPtr(uint offset) => this.Process.ReadPtr(this.Address + offset);
+        protected IntPtr ReadPtr(int offset) => this.Process.ReadPtr(this.Address + offset);
 
-        protected string ReadString(uint offset) => this.Process.ReadAsciiStringPtr(this.Address + offset);
+        protected string ReadString(int offset) => this.Process.ReadAsciiStringPtr(this.Address + offset);
 
-        protected uint ReadUInt32(uint offset) => this.Process.ReadUInt32(this.Address + offset);
+        protected uint ReadUInt32(int offset) => this.Process.ReadUInt32(this.Address + offset);
 
-        protected byte ReadByte(uint offset) => this.Process.ReadByte(this.Address + offset);
+        protected byte ReadByte(int offset) => this.Process.ReadByte(this.Address + offset);
     }
 }

--- a/src/HackF5.UnitySpy/Detail/MemoryObject.cs
+++ b/src/HackF5.UnitySpy/Detail/MemoryObject.cs
@@ -12,6 +12,11 @@
             this.Address = address;
         }
 
+        public uint GetAddress()
+        {
+            return this.Address;
+        }
+
         IAssemblyImage IMemoryObject.Image => this.Image;
 
         public virtual AssemblyImage Image { get; }
@@ -27,5 +32,7 @@
         protected string ReadString(uint offset) => this.Process.ReadAsciiStringPtr(this.Address + offset);
 
         protected uint ReadUInt32(uint offset) => this.Process.ReadUInt32(this.Address + offset);
+
+        protected byte ReadByte(uint offset) => this.Process.ReadByte(this.Address + offset);
     }
 }

--- a/src/HackF5.UnitySpy/Detail/MemoryObject.cs
+++ b/src/HackF5.UnitySpy/Detail/MemoryObject.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace HackF5.UnitySpy.Detail
+﻿namespace HackF5.UnitySpy.Detail
 {
+    using System;
+
     /// <summary>
     /// The base type for all objects accessed in a process' memory. Every object has an address in memory
     /// and all information about that object is accessed via an offset from that address.
@@ -12,11 +12,6 @@ namespace HackF5.UnitySpy.Detail
         {
             this.Image = image;
             this.Address = address;
-        }
-
-        public IntPtr GetAddress()
-        {
-            return this.Address;
         }
 
         IAssemblyImage IMemoryObject.Image => this.Image;

--- a/src/HackF5.UnitySpy/Detail/MonoClassKind.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoClassKind.cs
@@ -1,0 +1,12 @@
+﻿namespace HackF5.UnitySpy.Detail
+{
+    public enum MonoClassKind
+    {
+        Def = 1,
+        GTg = 2,
+        GInst = 3,
+        GParam = 4,
+        Array = 5,
+        Pointer = 6,
+    }
+}

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -167,7 +167,7 @@ namespace HackF5.UnitySpy.Detail
                 && unityVersion.StartsWith(offsets.UnityVersion)
             );
 
-            // TODO add code to find de best candidate instead of throwring exception.
+            // TODO add code to find the best candidate instead of throwing exception.
             if (monoLibraryOffsets == null)
             {
                 string mode = is64Bits ? "in 64 bits mode" : "in 32 Bits mode";

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -1,51 +1,129 @@
 ﻿// ReSharper disable IdentifierTypo
 namespace HackF5.UnitySpy.Detail
 {
-    // Remember that here pointers are 4 bytes
-    internal static class MonoLibraryOffsets
+    using System;
+    using System.Collections.Generic;
+
+    public class MonoLibraryOffsets
     {
-        public const uint AssemblyImage = 0x44;
 
-        public const uint ImageClassCache = 0x354;
+        public static readonly MonoLibraryOffsets Unity2018_4_10_x86_Offests = new MonoLibraryOffsets
+        {
+            UnityVersion = "2018.4.10",
+            Is64Bits = false,
 
-        public const uint HashTableSize = 0xc;
+            AssemblyImage = 0x44,
+            ReferencedAssemblies = 0x6c,
+            ImageClassCache = 0x354,
+            HashTableSize = 0xc,
+            HashTableTable = 0x14,
+            
+            TypeDefinitionFieldSize = 0x10,
+            TypeDefinitionBitFields = 0x14,
+            TypeDefinitionClassKind = 0x1e,
+            TypeDefinitionParent = 0x20,
+            TypeDefinitionNestedIn = 0x24,
+            TypeDefinitionName = 0x2c,
+            TypeDefinitionNamespace = 0x30,
+            TypeDefinitionVTableSize = 0x38,
+            TypeDefinitionSize = 0x5c,
+            TypeDefinitionFields = 0x60,
+            TypeDefinitionByValArg = 0x74,
+            TypeDefinitionRuntimeInfo = 0x84,
 
-        public const uint HashTableTable = 0x14;
+            TypeDefinitionFieldCount = 0xa4,
+            TypeDefinitionNextClassCache = 0xa8,
 
-        public const uint TypeDefinitionBitFields = 0x14;
+            TypeDefinitionGenericContainer = 0x94,
+            
+            TypeDefinitionRuntimeInfoDomainVtables = 0x4,
 
-        public const uint TypeDefinitionByValArg = 0x74;
+            VTable = 0x28
+        };
 
-        public const uint TypeDefinitionFieldCount = 0xa4;
+        private static readonly List<MonoLibraryOffsets> supportedVersions = new List<MonoLibraryOffsets>()
+        {
+            Unity2018_4_10_x86_Offests
+        };
 
-        public const uint TypeDefinitionFields = 0x60;
+        public string UnityVersion { get; private set; }
 
-        public const uint TypeDefinitionFieldSize = 0x10;
+        public bool Is64Bits { get; private set; }
 
-        public const uint TypeDefinitionName = 0x2c;
+        public int AssemblyImage { get; private set; }
 
-        public const uint TypeDefinitionNamespace = 0x30;
+        public int ReferencedAssemblies { get; private set; }
 
-        public const uint TypeDefinitionNestedIn = 0x24;
+        public int ImageClassCache { get; private set; }
 
-        public const uint TypeDefinitionNextClassCache = 0xa8;
+        public int HashTableSize { get; private set; }
 
-        public const uint TypeDefinitionParent = 0x20;
+        public int HashTableTable { get; private set; }
 
-        public const uint TypeDefinitionRuntimeInfo = 0x84;
 
-        public const uint TypeDefinitionSize = 0x5c;
+        // MonoClass Offsets
 
-        public const uint TypeDefinitionRuntimeInfoDomainVtables = 0x4;
+        public int TypeDefinitionFieldSize { get; private set; }
 
-        public const uint ReferencedAssemblies = 0x6c;
+        public int TypeDefinitionBitFields { get; private set; }
 
-        public const uint TypeDefinitionVTableSize = 0x38;
+        public int TypeDefinitionClassKind { get; private set; }
 
-        public const uint TypeDefinitionClassKind = 0x1e;
+        public int TypeDefinitionParent { get; private set; }
 
-        public const uint TypeDefinitionSizeOf = 0x94;
+        public int TypeDefinitionNestedIn { get; private set; }
 
-        public const uint VTable = 0x28;
+        public int TypeDefinitionName { get; private set; }
+
+        public int TypeDefinitionNamespace { get; private set; }
+
+        public int TypeDefinitionVTableSize { get; private set; }
+
+        public int TypeDefinitionSize { get; private set; }
+
+        public int TypeDefinitionFields { get; private set; }
+
+        public int TypeDefinitionByValArg { get; private set; }
+
+        public int TypeDefinitionRuntimeInfo { get; private set; }
+
+
+        // MonoClassDef Offsets
+
+        public int TypeDefinitionFieldCount { get; private set; }
+
+        public int TypeDefinitionNextClassCache { get; private set; }
+
+
+        // MonoClassGtd Offsets
+
+        public int TypeDefinitionGenericContainer { get; private set; }
+
+
+        // MonoClassRuntimeInfo Offsets
+
+        public int TypeDefinitionRuntimeInfoDomainVtables { get; private set; }
+
+
+        // MonoVTable Offsets
+
+        public int VTable { get; private set; }
+
+        public static MonoLibraryOffsets GetOffsets(string unityVersion, bool is64Bits)
+        {
+            MonoLibraryOffsets monoLibraryOffsets = supportedVersions.Find(
+                   offsets => offsets.Is64Bits == is64Bits
+                && unityVersion.StartsWith(offsets.UnityVersion)
+            );
+
+            if(monoLibraryOffsets == null)
+            {
+                string mode = is64Bits ? "in 64 bits mode" : "in 32 Bits mode";
+                throw new NotSupportedException($"The unity version the process is running " +
+                    $"({unityVersion} {mode}) is not supported");
+            }
+
+            return monoLibraryOffsets;
+        }
     }
 }

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -3,6 +3,8 @@ namespace HackF5.UnitySpy.Detail
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
 
     public class MonoLibraryOffsets
     {
@@ -152,18 +154,67 @@ namespace HackF5.UnitySpy.Detail
         // Managed String Offsets
 
         public int UnicodeString { get; private set; }
-        
 
-        public static MonoLibraryOffsets GetOffsets(string unityVersion, bool is64Bits)
+        public static MonoLibraryOffsets GetOffsets(string gameExecutableFilePath, bool force = true)
+        {
+            FileVersionInfo myFileVersionInfo = FileVersionInfo.GetVersionInfo(gameExecutableFilePath);
+            string unityVersion = myFileVersionInfo.FileVersion;
+
+            // Taken from here https://stackoverflow.com/questions/1001404/check-if-unmanaged-dll-is-32-bit-or-64-bit;
+            // See http://www.microsoft.com/whdc/system/platform/firmware/PECOFF.mspx
+            // Offset to PE header is always at 0x3C.
+            // The PE header starts with "PE\0\0" =  0x50 0x45 0x00 0x00,
+            // followed by a 2-byte machine type field (see the document above for the enum).
+            //
+            FileStream fs = new FileStream(gameExecutableFilePath, FileMode.Open, FileAccess.Read);
+            BinaryReader br = new BinaryReader(fs);
+            fs.Seek(0x3c, SeekOrigin.Begin);
+            Int32 peOffset = br.ReadInt32();
+            fs.Seek(peOffset, SeekOrigin.Begin);
+            UInt32 peHead = br.ReadUInt32();
+
+            if (peHead != 0x00004550) // "PE\0\0", little-endian
+            {
+                throw new Exception("Can't find PE header");
+            }
+
+            int machineType = br.ReadUInt16();
+            br.Close();
+            fs.Close();
+
+            switch (machineType)
+            {
+                case 0x8664: // IMAGE_FILE_MACHINE_AMD64
+                    return GetOffsets(unityVersion, true, force);
+                case 0x14c: // IMAGE_FILE_MACHINE_I386
+                    return GetOffsets(unityVersion, false, force);
+                default:
+                    throw new NotSupportedException("Platform not supported");
+            }
+        }
+
+        public static MonoLibraryOffsets GetOffsets(string unityVersion, bool is64Bits, bool force = true)
         {
             MonoLibraryOffsets monoLibraryOffsets = SupportedVersions.Find(
                    offsets => offsets.Is64Bits == is64Bits
                 && unityVersion.StartsWith(offsets.UnityVersion)
             );
 
-            // TODO add code to find the best candidate instead of throwing exception.
             if (monoLibraryOffsets == null)
             {
+                if(force)
+                {
+                    List<MonoLibraryOffsets> matchingArchitectureSupportedVersion = SupportedVersions.FindAll(v => v.Is64Bits == is64Bits);
+                    if(matchingArchitectureSupportedVersion.Count == 1)
+                    {
+                        return matchingArchitectureSupportedVersion[0];
+                    }
+                    else if(matchingArchitectureSupportedVersion.Count > 1)
+                    {
+                        // TODO add code to find the best candidate instead of throwing exception.
+                    }
+                }
+
                 string mode = is64Bits ? "in 64 bits mode" : "in 32 Bits mode";
                 throw new NotSupportedException($"The unity version the process is running " +
                     $"({unityVersion} {mode}) is not supported");

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -40,8 +40,7 @@ namespace HackF5.UnitySpy.Detail
 
             VTable = 0x28,
 
-            UnicodeString = 0xc,
-            UsesArrayDefinitionSize = true
+            UnicodeString = 0xc
         };
 
         public static readonly MonoLibraryOffsets Unity2019_4_5_x64_Offests = new MonoLibraryOffsets
@@ -63,8 +62,8 @@ namespace HackF5.UnitySpy.Detail
             TypeDefinitionName = 0x2c + 0x1c,                           // 0x48
             TypeDefinitionNamespace = 0x30 + 0x20,                      // 0x50
             TypeDefinitionVTableSize = 0x38 + 0x24,
-            TypeDefinitionSize = 0x5c + 0x20,
-            TypeDefinitionFields = 0x60 + 0x20 + 0x18,                  // 0x80
+            TypeDefinitionSize = 0x5c + 0x20 + 0x18 - 0x4,              // 0x90 Array Element Count
+            TypeDefinitionFields = 0x60 + 0x20 + 0x18,                  // 0x98
             TypeDefinitionByValArg = 0x74 + 0x44,
             TypeDefinitionRuntimeInfo = 0x84 + 0x34 + 0x18,             // 0xB8
 
@@ -77,8 +76,7 @@ namespace HackF5.UnitySpy.Detail
 
             VTable = 0x28 + 0x18,
 
-            UnicodeString = 0x14,
-            UsesArrayDefinitionSize = false
+            UnicodeString = 0x14
         };
 
         private static readonly List<MonoLibraryOffsets> SupportedVersions = new List<MonoLibraryOffsets>()
@@ -154,11 +152,7 @@ namespace HackF5.UnitySpy.Detail
         // Managed String Offsets
 
         public int UnicodeString { get; private set; }
-
-
-        // Managed Array Offsets
-
-        public bool UsesArrayDefinitionSize { get; private set; }
+        
 
         public static MonoLibraryOffsets GetOffsets(string unityVersion, bool is64Bits)
         {

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -1,34 +1,51 @@
 ﻿// ReSharper disable IdentifierTypo
 namespace HackF5.UnitySpy.Detail
 {
+    // Remember that here pointers are 4 bytes
     internal static class MonoLibraryOffsets
     {
-        public const uint AssemblyImage = 0x40;
+        public const uint AssemblyImage = 0x44;
+
+        public const uint ImageClassCache = 0x354;
+
+        public const uint HashTableSize = 0xc;
+
+        public const uint HashTableTable = 0x14;
 
         public const uint TypeDefinitionBitFields = 0x14;
 
-        public const uint TypeDefinitionByValArg = 0x8c;
+        public const uint TypeDefinitionByValArg = 0x74;
 
-        public const uint TypeDefinitionFieldCount = 0x68;
+        public const uint TypeDefinitionFieldCount = 0xa4;
 
-        public const uint TypeDefinitionFields = 0x78;
+        public const uint TypeDefinitionFields = 0x60;
 
-        public const uint TypeDefinitionName = 0x34;
+        public const uint TypeDefinitionFieldSize = 0x10;
 
-        public const uint TypeDefinitionNamespace = 0x38;
+        public const uint TypeDefinitionName = 0x2c;
 
-        public const uint TypeDefinitionNestedIn = 0x28;
+        public const uint TypeDefinitionNamespace = 0x30;
 
-        public const uint TypeDefinitionNextClassCache = 0xac;
+        public const uint TypeDefinitionNestedIn = 0x24;
 
-        public const uint TypeDefinitionParent = 0x24;
+        public const uint TypeDefinitionNextClassCache = 0xa8;
 
-        public const uint TypeDefinitionRuntimeInfo = 0xa8;
+        public const uint TypeDefinitionParent = 0x20;
+
+        public const uint TypeDefinitionRuntimeInfo = 0x84;
 
         public const uint TypeDefinitionSize = 0x5c;
 
         public const uint TypeDefinitionRuntimeInfoDomainVtables = 0x4;
 
-        public const uint ReferencedAssemblies = 0x70;
-   }
+        public const uint ReferencedAssemblies = 0x6c;
+
+        public const uint TypeDefinitionVTableSize = 0x38;
+
+        public const uint TypeDefinitionClassKind = 0x1e;
+
+        public const uint TypeDefinitionSizeOf = 0x94;
+
+        public const uint VTable = 0x28;
+    }
 }

--- a/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/MonoLibraryOffsets.cs
@@ -38,12 +38,53 @@ namespace HackF5.UnitySpy.Detail
             
             TypeDefinitionRuntimeInfoDomainVtables = 0x4,
 
-            VTable = 0x28
+            VTable = 0x28,
+
+            UnicodeString = 0xc,
+            UsesArrayDefinitionSize = true
         };
 
-        private static readonly List<MonoLibraryOffsets> supportedVersions = new List<MonoLibraryOffsets>()
+        public static readonly MonoLibraryOffsets Unity2019_4_5_x64_Offests = new MonoLibraryOffsets
         {
-            Unity2018_4_10_x86_Offests
+            UnityVersion = "2019.4.5",
+            Is64Bits = true,
+
+            AssemblyImage = 0x44 + 0x1c,
+            ReferencedAssemblies = 0x6c + 0x5c,
+            ImageClassCache = 0x354 + 0x16c,
+            HashTableSize = 0xc + 0xc,
+            HashTableTable = 0x14 + 0xc,
+
+            TypeDefinitionFieldSize = 0x10 + 0x10,
+            TypeDefinitionBitFields = 0x14 + 0xc,
+            TypeDefinitionClassKind = 0x1e + 0xc,
+            TypeDefinitionParent = 0x20 + 0x10,                         // 0x30
+            TypeDefinitionNestedIn = 0x24 + 0x14,                       // 0x38
+            TypeDefinitionName = 0x2c + 0x1c,                           // 0x48
+            TypeDefinitionNamespace = 0x30 + 0x20,                      // 0x50
+            TypeDefinitionVTableSize = 0x38 + 0x24,
+            TypeDefinitionSize = 0x5c + 0x20,
+            TypeDefinitionFields = 0x60 + 0x20 + 0x18,                  // 0x80
+            TypeDefinitionByValArg = 0x74 + 0x44,
+            TypeDefinitionRuntimeInfo = 0x84 + 0x34 + 0x18,             // 0xB8
+
+            TypeDefinitionFieldCount = 0xa4 + 0x34 + 0x10 + 0x18,
+            TypeDefinitionNextClassCache = 0xa8 + 0x34 + 0x10 + 0x18 + 0x4,
+
+            TypeDefinitionGenericContainer = 0x94 + 0x34 + 0x18 + 0x10,
+
+            TypeDefinitionRuntimeInfoDomainVtables = 0x4 + 0x4,
+
+            VTable = 0x28 + 0x18,
+
+            UnicodeString = 0x14,
+            UsesArrayDefinitionSize = false
+        };
+
+        private static readonly List<MonoLibraryOffsets> SupportedVersions = new List<MonoLibraryOffsets>()
+        {
+            Unity2018_4_10_x86_Offests,
+            Unity2019_4_5_x64_Offests
         };
 
         public string UnityVersion { get; private set; }
@@ -109,14 +150,25 @@ namespace HackF5.UnitySpy.Detail
 
         public int VTable { get; private set; }
 
+
+        // Managed String Offsets
+
+        public int UnicodeString { get; private set; }
+
+
+        // Managed Array Offsets
+
+        public bool UsesArrayDefinitionSize { get; private set; }
+
         public static MonoLibraryOffsets GetOffsets(string unityVersion, bool is64Bits)
         {
-            MonoLibraryOffsets monoLibraryOffsets = supportedVersions.Find(
+            MonoLibraryOffsets monoLibraryOffsets = SupportedVersions.Find(
                    offsets => offsets.Is64Bits == is64Bits
                 && unityVersion.StartsWith(offsets.UnityVersion)
             );
 
-            if(monoLibraryOffsets == null)
+            // TODO add code to find de best candidate instead of throwring exception.
+            if (monoLibraryOffsets == null)
             {
                 string mode = is64Bits ? "in 64 bits mode" : "in 32 Bits mode";
                 throw new NotSupportedException($"The unity version the process is running " +

--- a/src/HackF5.UnitySpy/Detail/PEFormatOffsets.cs
+++ b/src/HackF5.UnitySpy/Detail/PEFormatOffsets.cs
@@ -1,0 +1,29 @@
+﻿// ReSharper disable IdentifierTypo
+namespace HackF5.UnitySpy.Detail
+{
+
+    public class PEFormatOffsets
+    {
+        // offsets taken from https://docs.microsoft.com/en-us/windows/desktop/Debug/pe-format
+        public const int Signature = 0x3c;
+
+        // 32 bits
+        public const int ExportDirectoryIndexPE = 0x78;
+
+        // 64 bits
+        public const int ExportDirectoryIndexPE32Plus = 0x88;
+
+        public const int NumberOfFunctions = 0x14;
+
+        public const int FunctionAddressArrayIndex = 0x1c;
+
+        public const int FunctionNameArrayIndex = 0x20;
+
+        public const int FunctionEntrySize = 4;
+
+        public static int GetExportDirectoryIndex(bool is64Bits)
+        {
+            return is64Bits ? ExportDirectoryIndexPE32Plus : ExportDirectoryIndexPE;
+        }
+    }
+}

--- a/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
+++ b/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
@@ -228,17 +228,13 @@
             var arrayDefinitionPtr = this.ReadPtr(vtable);
             var arrayDefinition = type.Image.GetTypeDefinition(arrayDefinitionPtr);
             var elementDefinition = type.Image.GetTypeDefinition(this.ReadPtr(arrayDefinitionPtr));
-
-            // Not sure why in the new version of unity the array it seems to have pointers instead of the element
-            // Maybe mono changed?
-            var elementSize = MonoLibraryOffsets.UsesArrayDefinitionSize ? arrayDefinition.Size : SizeOfPtr;
-
+            
             var count = this.ReadInt32(ptr + SizeOfPtr * 3);
             var start = ptr + (SizeOfPtr * 4);
             var result = new object[count];
             for (var i = 0; i < count; i++)
             {
-                result[i] = elementDefinition.TypeInfo.GetValue(start + (i * elementSize));
+                result[i] = elementDefinition.TypeInfo.GetValue(start + (i * arrayDefinition.Size));
             }
 
             return result;

--- a/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
+++ b/src/HackF5.UnitySpy/Detail/ProcessFacade.cs
@@ -229,14 +229,16 @@
             var arrayDefinition = type.Image.GetTypeDefinition(arrayDefinitionPtr);
             var elementDefinition = type.Image.GetTypeDefinition(this.ReadPtr(arrayDefinitionPtr));
 
+            // Not sure why in the new version of unity the array it seems to have pointers instead of the element
+            // Maybe mono changed?
             var elementSize = MonoLibraryOffsets.UsesArrayDefinitionSize ? arrayDefinition.Size : SizeOfPtr;
 
             var count = this.ReadInt32(ptr + SizeOfPtr * 3);
-            var start = ptr + SizeOfPtr * 4;
+            var start = ptr + (SizeOfPtr * 4);
             var result = new object[count];
             for (var i = 0; i < count; i++)
             {
-                result[i] = elementDefinition.TypeInfo.GetValue(start + i * elementSize);
+                result[i] = elementDefinition.TypeInfo.GetValue(start + (i * elementSize));
             }
 
             return result;

--- a/src/HackF5.UnitySpy/Detail/TypeCode.cs
+++ b/src/HackF5.UnitySpy/Detail/TypeCode.cs
@@ -50,6 +50,7 @@ namespace HackF5.UnitySpy.Detail
 
         [Description("string")]
         STRING = 0x0e,
+
         PTR = 0x0f,         /* arg: <type> token */
         BYREF = 0x10,       /* arg: <type> token */
         VALUETYPE = 0x11,   /* arg: <type> token */
@@ -64,6 +65,7 @@ namespace HackF5.UnitySpy.Detail
 
         [Description("uint")]
         U = 0x19,
+
         FNPTR = 0x1b,       /* arg: full method signature */
         OBJECT = 0x1c,
         SZARRAY = 0x1d,     /* 0-based one-dim-array */

--- a/src/HackF5.UnitySpy/Detail/TypeDefinition.cs
+++ b/src/HackF5.UnitySpy/Detail/TypeDefinition.cs
@@ -1,7 +1,6 @@
 ﻿namespace HackF5.UnitySpy.Detail
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
@@ -9,6 +8,7 @@
     using System.Text;
     using HackF5.UnitySpy.Util;
     using JetBrains.Annotations;
+    using System.Collections.Concurrent;
 
     /// <summary>
     /// Represents an unmanaged _MonoClass instance in a Mono process. This object describes the type of a class or
@@ -34,6 +34,8 @@
 
         private readonly Lazy<TypeDefinition> lazyParent;
 
+        private readonly Lazy<TypeDefinition> lazyGeneric;
+
         public TypeDefinition([NotNull] AssemblyImage image, uint address)
             : base(image, address)
         {
@@ -48,6 +50,7 @@
             this.lazyNestedIn = new Lazy<TypeDefinition>(() => this.GetClassDefinition(MonoLibraryOffsets.TypeDefinitionNestedIn));
             this.lazyFullName = new Lazy<string>(this.GetFullName);
             this.lazyFields = new Lazy<IReadOnlyList<FieldDefinition>>(this.GetFields);
+            this.lazyGeneric = new Lazy<TypeDefinition>(this.GetGeneric);
 
             this.Name = this.ReadString(MonoLibraryOffsets.TypeDefinitionName);
             this.NamespaceName = this.ReadString(MonoLibraryOffsets.TypeDefinitionNamespace);
@@ -55,15 +58,17 @@
             var vtablePtr = this.ReadPtr(MonoLibraryOffsets.TypeDefinitionRuntimeInfo);
             this.VTable = vtablePtr == Constants.NullPtr ? Constants.NullPtr : image.Process.ReadPtr(vtablePtr + MonoLibraryOffsets.TypeDefinitionRuntimeInfoDomainVtables);
             this.TypeInfo = new TypeInfo(image, this.Address + MonoLibraryOffsets.TypeDefinitionByValArg);
+            this.VTableSize = vtablePtr == Constants.NullPtr ? Constants.NullPtr : this.ReadInt32(MonoLibraryOffsets.TypeDefinitionVTableSize);
+            this.ClassKind = (MonoClassKind)(this.ReadByte(MonoLibraryOffsets.TypeDefinitionClassKind) & 0x7);
         }
 
         IReadOnlyList<IFieldDefinition> ITypeDefinition.Fields => this.Fields;
 
         public string FullName => this.lazyFullName.Value;
 
-        public bool IsEnum => (this.bitFields & 0x10) == 0x10;
+        public bool IsEnum => (this.bitFields & 0x8) == 0x8;
 
-        public bool IsValueType => (this.bitFields & 0x8) == 0x8;
+        public bool IsValueType => (this.bitFields & 0x4) == 0x4;
 
         public string Name { get; }
 
@@ -83,6 +88,10 @@
 
         public uint VTable { get; }
 
+        public int VTableSize { get; }
+
+        public MonoClassKind ClassKind { get; }
+
         public dynamic this[string fieldName] => this.GetStaticValue<dynamic>(fieldName);
 
         IFieldDefinition ITypeDefinition.GetField(string fieldName, string typeFullName) =>
@@ -91,9 +100,7 @@
         public TValue GetStaticValue<TValue>(string fieldName)
         {
             var field = this.GetField(fieldName, this.FullName)
-                ?? throw new ArgumentException(
-                    $"Field '{fieldName}' does not exist in class '{this.FullName}'.",
-                    nameof(fieldName));
+                ?? throw new ArgumentException($"Field '{fieldName}' does not exist in class '{this.FullName}'.", nameof(fieldName));
 
             if (!field.TypeInfo.IsStatic)
             {
@@ -105,7 +112,16 @@
                 throw new InvalidOperationException($"Field '{fieldName}' is constant in class '{this.FullName}'.");
             }
 
-            return field.GetValue<TValue>(this.Process.ReadPtr(this.VTable + 0xc));
+            try
+            {
+                return field.GetValue<TValue>(this.Process.ReadPtr(this.VTable + MonoLibraryOffsets.VTable + (uint)(4 * this.VTableSize)));
+            } 
+            catch (Exception e)
+            {
+                throw new Exception(
+                    $"Exception received when trying to get static value for field '{fieldName}' in class '{this.FullName}': ${e.Message}.", 
+                    e);
+            }
         }
 
         public FieldDefinition GetField(string fieldName, string typeFullName = default) =>
@@ -129,22 +145,29 @@
             var firstField = this.ReadPtr(MonoLibraryOffsets.TypeDefinitionFields);
             if (firstField == Constants.NullPtr)
             {
-                return this.Parent?.Fields ?? Array.Empty<FieldDefinition>();
+                return this.Parent?.Fields ?? new List<FieldDefinition>();
             }
 
             var fields = new List<FieldDefinition>();
-            for (var fieldIndex = 0u; fieldIndex < this.fieldCount; fieldIndex++)
+            if (this.ClassKind == MonoClassKind.GInst)
             {
-                var field = firstField + (fieldIndex * 0x10);
-                if (this.Process.ReadPtr(field) == Constants.NullPtr)
+                fields.AddRange(this.GetGeneric().GetFields());
+            }
+            else
+            {
+                for (var fieldIndex = 0u; fieldIndex < this.fieldCount; fieldIndex++)
                 {
-                    break;
-                }
+                    var field = firstField + (fieldIndex * MonoLibraryOffsets.TypeDefinitionFieldSize);
+                    if (this.Process.ReadPtr(field) == Constants.NullPtr)
+                    {
+                        break;
+                    }
 
-                fields.Add(new FieldDefinition(this, field));
+                    fields.Add(new FieldDefinition(this, field));
+                }
             }
 
-            fields.AddRange(this.Parent?.Fields ?? Array.Empty<FieldDefinition>());
+            fields.AddRange(this.Parent?.Fields ?? new List<FieldDefinition>());
 
             return new ReadOnlyCollection<FieldDefinition>(fields.OrderBy(f => f.Name).ToArray());
         }
@@ -178,6 +201,16 @@
 
                 nested = nested.NestedIn;
             }
+        }
+
+        private TypeDefinition GetGeneric()
+        {
+            if (this.ClassKind != MonoClassKind.GInst)
+            {
+                return null;
+            }
+
+            return this.Image.GetTypeDefinition(this.Image.Process.ReadPtr(this.ReadPtr(MonoLibraryOffsets.TypeDefinitionSizeOf)));
         }
     }
 }

--- a/src/HackF5.UnitySpy/Detail/TypeDefinition.cs
+++ b/src/HackF5.UnitySpy/Detail/TypeDefinition.cs
@@ -114,7 +114,9 @@
 
             try
             {
-                return field.GetValue<TValue>(this.Process.ReadPtr(this.VTable + this.Process.MonoLibraryOffsets.VTable + 4 * this.VTableSize));
+                var vTableMemorySize = this.Process.SizeOfPtr * this.VTableSize;
+                var valuePtr = this.Process.ReadPtr(this.VTable + this.Process.MonoLibraryOffsets.VTable + vTableMemorySize);
+                return field.GetValue<TValue>(valuePtr);
             } 
             catch (Exception e)
             {

--- a/src/HackF5.UnitySpy/Detail/TypeInfo.cs
+++ b/src/HackF5.UnitySpy/Detail/TypeInfo.cs
@@ -1,7 +1,6 @@
-﻿using System;
-
-namespace HackF5.UnitySpy.Detail
+﻿namespace HackF5.UnitySpy.Detail
 {
+    using System;
     using JetBrains.Annotations;
 
     /// <summary>

--- a/src/HackF5.UnitySpy/Detail/TypeInfo.cs
+++ b/src/HackF5.UnitySpy/Detail/TypeInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace HackF5.UnitySpy.Detail
+﻿using System;
+
+namespace HackF5.UnitySpy.Detail
 {
     using JetBrains.Annotations;
 
@@ -10,16 +12,16 @@
     [PublicAPI]
     public class TypeInfo : MemoryObject, ITypeInfo
     {
-        public TypeInfo(AssemblyImage image, uint address)
+        public TypeInfo(AssemblyImage image, IntPtr address)
             : base(image, address)
         {
-            this.Data = this.ReadUInt32(0x0);
-            this.Attrs = this.ReadUInt32(0x4);
+            this.Data = this.ReadPtr(0x0);
+            this.Attrs = this.ReadUInt32(this.Process.SizeOfPtr);
         }
 
         public uint Attrs { get; }
 
-        public uint Data { get; }
+        public IntPtr Data { get; }
 
         public bool IsStatic => (this.Attrs & 0x10) == 0x10;
 
@@ -43,6 +45,6 @@
             }
         }
 
-        public object GetValue(uint address) => this.Process.ReadManaged(this, address);
+        public object GetValue(IntPtr address) => this.Process.ReadManaged(this, address);
     }
 }

--- a/src/HackF5.UnitySpy/HackF5.UnitySpy.csproj
+++ b/src/HackF5.UnitySpy/HackF5.UnitySpy.csproj
@@ -16,7 +16,8 @@
   </PropertyGroup>
 
  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-  </PropertyGroup>
+   <PlatformTarget>x64</PlatformTarget>
+ </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Jetbrains.Annotations" Version="2019.1.1" />

--- a/src/HackF5.UnitySpy/IManagedObjectInstance.cs
+++ b/src/HackF5.UnitySpy/IManagedObjectInstance.cs
@@ -50,5 +50,7 @@
         /// The value of the field in the instance with the given <paramref name="fieldName"/>.
         /// </returns>
         TValue GetValue<TValue>(string fieldName, string typeFullName);
+
+        uint GetAddress();
     }
 }

--- a/src/HackF5.UnitySpy/IManagedObjectInstance.cs
+++ b/src/HackF5.UnitySpy/IManagedObjectInstance.cs
@@ -1,6 +1,7 @@
 ﻿namespace HackF5.UnitySpy
 {
     using JetBrains.Annotations;
+    using System;
 
     /// <summary>
     /// Represents an object instance in managed memory.
@@ -51,6 +52,6 @@
         /// </returns>
         TValue GetValue<TValue>(string fieldName, string typeFullName);
 
-        uint GetAddress();
+        IntPtr GetAddress();
     }
 }

--- a/src/HackF5.UnitySpy/IManagedObjectInstance.cs
+++ b/src/HackF5.UnitySpy/IManagedObjectInstance.cs
@@ -51,7 +51,5 @@
         /// The value of the field in the instance with the given <paramref name="fieldName"/>.
         /// </returns>
         TValue GetValue<TValue>(string fieldName, string typeFullName);
-
-        IntPtr GetAddress();
     }
 }

--- a/src/HackF5.UnitySpy/Util/Constants.cs
+++ b/src/HackF5.UnitySpy/Util/Constants.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace HackF5.UnitySpy.Util
+﻿namespace HackF5.UnitySpy.Util
 {
+    using System;
+    
     public static class Constants
     {
         public static IntPtr NullPtr => IntPtr.Zero;

--- a/src/HackF5.UnitySpy/Util/Constants.cs
+++ b/src/HackF5.UnitySpy/Util/Constants.cs
@@ -1,9 +1,10 @@
-﻿namespace HackF5.UnitySpy.Util
+﻿using System;
+
+namespace HackF5.UnitySpy.Util
 {
     public static class Constants
     {
-        public const int NullPtr = 0;
+        public static IntPtr NullPtr => IntPtr.Zero;
 
-        public const uint SizeOfPtr = sizeof(uint);
     }
 }

--- a/src/HackF5.UnitySpy/Util/ConversionUtils.cs
+++ b/src/HackF5.UnitySpy/Util/ConversionUtils.cs
@@ -16,6 +16,8 @@
 
         public static uint ToUInt32(this byte[] buffer, int start = 0) => BitConverter.ToUInt32(buffer, start);
 
+        public static ulong ToUInt64(this byte[] buffer, int start = 0) => BitConverter.ToUInt64(buffer, start);
+
         public static char ToChar(this byte[] buffer) => BitConverter.ToChar(buffer, 0);
 
         public static ushort ToUInt16(this byte[] buffer) => BitConverter.ToUInt16(buffer, 0);
@@ -29,5 +31,7 @@
         public static float ToSingle(this byte[] buffer) => BitConverter.ToSingle(buffer, 0);
 
         public static double ToDouble(this byte[] buffer) => BitConverter.ToDouble(buffer, 0);
+
+        public static byte ToByte(this byte[] buffer) => buffer[0];
     }
 }

--- a/src/HackF5.UnitySpy/Util/ConversionUtils.cs
+++ b/src/HackF5.UnitySpy/Util/ConversionUtils.cs
@@ -8,7 +8,7 @@
     {
         public static string ToAsciiString(this byte[] buffer, int start = 0)
         {
-            var length = buffer.Skip(start).TakeWhile(b => b != Constants.NullPtr).Count();
+            var length = buffer.Skip(start).TakeWhile(b => b != 0).Count();
             return Encoding.ASCII.GetString(buffer, start, length);
         }
 

--- a/src/HackF5.UnitySpy/Util/Native.cs
+++ b/src/HackF5.UnitySpy/Util/Native.cs
@@ -1,6 +1,7 @@
 ﻿namespace HackF5.UnitySpy.Util
 {
     using System;
+    using System.Diagnostics;
     using System.Runtime.InteropServices;
     using System.Text;
     using HackF5.UnitySpy.Detail;
@@ -25,7 +26,7 @@
 
         public static IntPtr[] GetProcessModulePointers(ProcessFacade process)
         {
-            var modulePointers = new IntPtr[2048 * Constants.SizeOfPtr];
+            var modulePointers = new IntPtr[2048 * process.SizeOfPtr];
 
             // Determine number of modules
             if (!Native.EnumProcessModulesEx(
@@ -54,6 +55,41 @@
             int cb,
             [MarshalAs(UnmanagedType.U4)] out int lpCbNeeded,
             uint dwFilterFlag);
+
+        // https://stackoverflow.com/questions/5497064/how-to-get-the-full-path-of-running-process
+        [DllImport("Kernel32.dll")]
+        private static extern bool QueryFullProcessImageName([In] IntPtr hProcess, [In] uint dwFlags, [Out] StringBuilder lpExeName, [In, Out] ref uint lpdwSize);
+
+        public static string GetMainModuleFileName(this Process process, int buffer = 1024)
+        {
+            var fileNameBuilder = new StringBuilder(buffer);
+            uint bufferLength = (uint)fileNameBuilder.Capacity + 1;
+            return QueryFullProcessImageName(process.Handle, 0, fileNameBuilder, ref bufferLength) ?
+                fileNameBuilder.ToString() :
+                null;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool IsWow64Process([In] IntPtr process, [Out] out bool wow64Process);
+
+        public static bool IsWow64Process(Process process)
+        {
+            if ((Environment.OSVersion.Version.Major > 5)
+                || ((Environment.OSVersion.Version.Major == 5) && (Environment.OSVersion.Version.Minor >= 1)))
+            {
+                if (!Environment.Is64BitOperatingSystem)
+                    return false;
+                // if this method is not available in your version of .NET, use GetNativeSystemInfo via P/Invoke instead
+
+                bool isWow64;
+                if (!IsWow64Process(process.Handle, out isWow64))
+                    throw new Exception("Something went wrong trying to figure out if the process is running a 64 bits or not");
+                return !isWow64;
+            }
+
+            return false; // not on 64-bit Windows Emulator
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         public struct ModuleInformation

--- a/src/HackF5.UnitySpy/Util/Native.cs
+++ b/src/HackF5.UnitySpy/Util/Native.cs
@@ -68,29 +68,7 @@
                 fileNameBuilder.ToString() :
                 null;
         }
-
-        [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool IsWow64Process([In] IntPtr process, [Out] out bool wow64Process);
-
-        public static bool IsWow64Process(Process process)
-        {
-            if ((Environment.OSVersion.Version.Major > 5)
-                || ((Environment.OSVersion.Version.Major == 5) && (Environment.OSVersion.Version.Minor >= 1)))
-            {
-                if (!Environment.Is64BitOperatingSystem)
-                    return false;
-                // if this method is not available in your version of .NET, use GetNativeSystemInfo via P/Invoke instead
-
-                bool isWow64;
-                if (!IsWow64Process(process.Handle, out isWow64))
-                    throw new Exception("Something went wrong trying to figure out if the process is running a 64 bits or not");
-                return !isWow64;
-            }
-
-            return false; // not on 64-bit Windows Emulator
-        }
-
+        
         [StructLayout(LayoutKind.Sequential)]
         public struct ModuleInformation
         {


### PR DESCRIPTION
Extended the support to 64 bits while maintaining the existing 32 bits support.

Once the process is selected, UnitySpy will use a set of offset collections depending on the unity version and whether is 64 bits or 32 bits.

For now if a unity version is not supported it will throw an exception. But I plan to add a fall back to the closest unity version currently supported to at least give it a chance.