### PR TITLE
Add Unity 2022.3.42f1 x64 offsets

### DIFF
--- a/src/HackF5.UnitySpy/Offsets/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Offsets/MonoLibraryOffsets.cs
@@ -83,9 +83,9 @@ namespace HackF5.UnitySpy.Offsets
             VTable = 0x28 + 0x18,
         };
 
-        public static readonly MonoLibraryOffsets Unity2021_3_14_x64_PE_Offsets = new MonoLibraryOffsets
+        public static readonly MonoLibraryOffsets Unity2021_3_2022_3_x64_PE_Offsets = new MonoLibraryOffsets
         {
-            UnityVersions = new List<UnityVersion>() { UnityVersion.Version2021_3_14 },
+            UnityVersions = new List<UnityVersion>() { UnityVersion.Version2021_3_14, UnityVersion.Version2022_3_42 },
             Is64Bits = true,
             Format = BinaryFormat.PE,
             MonoLibrary = "mono-2.0-bdwgc.dll",
@@ -187,7 +187,7 @@ namespace HackF5.UnitySpy.Offsets
             Unity2018_4_10_x86_PE_Offsets,
             Unity2019_4_2020_3_x64_PE_Offsets,
             Unity2019_4_2020_3_x64_MachO_Offsets,
-            Unity2021_3_14_x64_PE_Offsets,
+            Unity2021_3_2022_3_x64_PE_Offsets,
         };
 
         public List<UnityVersion> UnityVersions { get; private set; }

--- a/src/HackF5.UnitySpy/Offsets/UnityVersion.cs
+++ b/src/HackF5.UnitySpy/Offsets/UnityVersion.cs
@@ -9,6 +9,7 @@ namespace HackF5.UnitySpy.Offsets
         public static readonly UnityVersion Version2019_4_5 = new UnityVersion(2019, 4, 5);
         public static readonly UnityVersion Version2020_3_13 = new UnityVersion(2020, 3, 13);
         public static readonly UnityVersion Version2021_3_14 = new UnityVersion(2021, 3, 14);
+        public static readonly UnityVersion Version2022_3_42 = new UnityVersion(2022, 3, 42);
 
         public UnityVersion(int year, int versionWithinYear, int subversionWithinYear)
         {


### PR DESCRIPTION
Confirmed working with MTGA 2024.40.30.6688.

Hint: MTGA moved the collection information from the 'Assembly-Csharp' assembly to the 'Core' assembly.